### PR TITLE
chore: remove prediction URL from output

### DIFF
--- a/infra/README.md
+++ b/infra/README.md
@@ -43,7 +43,6 @@ Sample infrastructure detailed description.
 | annotate\_gcs\_function\_name | The name of the cloud function that annotates an image triggered by a GCS event. |
 | neos\_walkthrough\_url | Neos Tutorial URL |
 | vision\_annotations\_gcs | Output GCS bucket name. |
-| vision\_entrypoint\_url | The URL for requesting online prediction with HTTP request. |
 | vision\_input\_gcs | Input GCS bucket name. |
 
 <!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->

--- a/infra/examples/simple_example/README.md
+++ b/infra/examples/simple_example/README.md
@@ -13,7 +13,6 @@
 |------|-------------|
 | annotate\_gcs\_function\_name | The name of the cloud function that annotates an image triggered by a GCS event. |
 | vision\_annotations\_gcs | Cloud Storage of the vision annotations |
-| vision\_entrypoint\_url | The URL for requesting online prediction with HTTP request. |
 | vision\_input\_gcs | Cloud Storage of the vision input |
 
 <!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->

--- a/infra/examples/simple_example/outputs.tf
+++ b/infra/examples/simple_example/outputs.tf
@@ -24,10 +24,12 @@ output "vision_input_gcs" {
   value       = module.simple.vision_input_gcs
 }
 
+/*
 output "vision_entrypoint_url" {
   description = "The URL for requesting online prediction with HTTP request."
   value       = module.simple.vision_entrypoint_url
 }
+*/
 
 output "annotate_gcs_function_name" {
   description = "The name of the cloud function that annotates an image triggered by a GCS event."

--- a/infra/metadata.display.yaml
+++ b/infra/metadata.display.yaml
@@ -16,8 +16,6 @@ apiVersion: blueprints.cloud.google.com/v1alpha1
 kind: BlueprintMetadata
 metadata:
   name: terraform-ml-image-annotation-gcf-display
-  annotations:
-    config.kubernetes.io/local-config: "true"
 spec:
   info:
     title: Infrastructure for image annotation with ML and GCF

--- a/infra/metadata.yaml
+++ b/infra/metadata.yaml
@@ -24,7 +24,6 @@ spec:
     source:
       repo: https://github.com/GoogleCloudPlatform/terraform-ml-image-annotation-gcf.git
       sourceType: git
-      dir: /infra
     description:
       tagline: Sample infrastructure tagline.
       detailed: Sample infrastructure detailed description.
@@ -94,8 +93,6 @@ spec:
       description: Neos Tutorial URL
     - name: vision_annotations_gcs
       description: Output GCS bucket name.
-    - name: vision_entrypoint_url
-      description: The URL for requesting online prediction with HTTP request.
     - name: vision_input_gcs
       description: Input GCS bucket name.
   requirements:

--- a/infra/modules/cloudfunctions/metadata.display.yaml
+++ b/infra/modules/cloudfunctions/metadata.display.yaml
@@ -16,8 +16,6 @@ apiVersion: blueprints.cloud.google.com/v1alpha1
 kind: BlueprintMetadata
 metadata:
   name: terraform-ml-image-annotation-gcf-cloudfunctions-display
-  annotations:
-    config.kubernetes.io/local-config: "true"
 spec:
   info:
     title: cloudfunctions module

--- a/infra/modules/cloudfunctions/metadata.yaml
+++ b/infra/modules/cloudfunctions/metadata.yaml
@@ -24,7 +24,7 @@ spec:
     source:
       repo: https://github.com/GoogleCloudPlatform/terraform-ml-image-annotation-gcf.git
       sourceType: git
-      dir: /infra/modules/cloudfunctions
+      dir: cloudfunctions
     actuationTool:
       flavor: Terraform
       version: '>= 0.13'

--- a/infra/modules/storage/metadata.display.yaml
+++ b/infra/modules/storage/metadata.display.yaml
@@ -16,8 +16,6 @@ apiVersion: blueprints.cloud.google.com/v1alpha1
 kind: BlueprintMetadata
 metadata:
   name: terraform-ml-image-annotation-gcf-storage-display
-  annotations:
-    config.kubernetes.io/local-config: "true"
 spec:
   info:
     title: storage module

--- a/infra/modules/storage/metadata.yaml
+++ b/infra/modules/storage/metadata.yaml
@@ -24,7 +24,7 @@ spec:
     source:
       repo: https://github.com/GoogleCloudPlatform/terraform-ml-image-annotation-gcf.git
       sourceType: git
-      dir: /infra/modules/storage
+      dir: storage
     actuationTool:
       flavor: Terraform
       version: '>= 0.13'

--- a/infra/output.tf
+++ b/infra/output.tf
@@ -14,10 +14,12 @@
  * limitations under the License.
  */
 
+/*
 output "vision_entrypoint_url" {
   description = "The URL for requesting online prediction with HTTP request."
   value       = module.cloudfunctions.function_uri
 }
+*/
 
 output "vision_input_gcs" {
   description = "Input GCS bucket name."


### PR DESCRIPTION
For now, I've commented it. This was also tested using a local SiC deployment and is working as expected.