### PR TITLE
feat: enable duet ai on JSS project

### DIFF
--- a/infra/apis.tf
+++ b/infra/apis.tf
@@ -33,6 +33,7 @@ locals {
     "eventarc.googleapis.com",
     "storage.googleapis.com",
     # other:
+    "cloudaicompanion.googleapis.com",
     "iam.googleapis.com",
     "secretmanager.googleapis.com",
   ]


### PR DESCRIPTION
We are planning to use this JSS for a Duet AI workshop. We would like to enable Duet AI using Terraform so that participants do not need to enable it manually.