### PR TITLE
feat: allow list in features parameter

### DIFF
--- a/src/gcf/main.py
+++ b/src/gcf/main.py
@@ -110,7 +110,7 @@ def get_feature_by_name(feature_name: str) -> Optional[vision.Feature.Type]:
     return None
 
 
-def build_features_list(feature_names: str) -> Optional[list]:
+def build_features_list(feature_names: str | list) -> Optional[list]:
     """Gets a list of Vision features for given list of names.
 
     Args:
@@ -121,7 +121,11 @@ def build_features_list(feature_names: str) -> Optional[list]:
     """
 
     features_list = []
-    features_items = feature_names.split(",")
+
+    features_items = feature_names
+    if isinstance(feature_names, str):
+        features_items = feature_names.split(",")
+
     for feature_name in features_items:
         feature = get_feature_by_name(feature_name.upper().strip('"').strip())
         if feature:
@@ -531,7 +535,7 @@ def handle_annotation(request):
         logging.info("Env. features: %s", features_env)
         features_list = build_features_list(features_env)
     # override annotation features with the ones from the request if provided
-    if features_http and isinstance(features_http, str):
+    if features_http and isinstance(features_http, str | list):
         logging.info("Request features: %s", features_http)
         features_list = build_features_list(features_http)
     logging.info("Annotating for features: %s", features_list)

--- a/src/gcf/main.py
+++ b/src/gcf/main.py
@@ -531,7 +531,7 @@ def handle_annotation(request):
         logging.info("Env. features: %s", features_env)
         features_list = build_features_list(features_env)
     # override annotation features with the ones from the request if provided
-    if features_http:
+    if features_http and isinstance(features_http, str):
         logging.info("Request features: %s", features_http)
         features_list = build_features_list(features_http)
     logging.info("Annotating for features: %s", features_list)

--- a/src/gcf/main.py
+++ b/src/gcf/main.py
@@ -531,9 +531,9 @@ def handle_annotation(request):
         logging.info("Env. features: %s", features_env)
         features_list = build_features_list(features_env)
     # override annotation features with the ones from the request if provided
-    if features_http and isinstance(features_http, list):
-        features_http = ','.join(features_http)
-    if features_http and isinstance(features_http, str):
+    if features_http:
+        if isinstance(features_http, list):
+            features_http = ','.join(features_http)
         logging.info("Request features: %s", features_http)
         features_list = build_features_list(features_http)
     logging.info("Annotating for features: %s", features_list)

--- a/src/gcf/main.py
+++ b/src/gcf/main.py
@@ -110,7 +110,7 @@ def get_feature_by_name(feature_name: str) -> Optional[vision.Feature.Type]:
     return None
 
 
-def build_features_list(feature_names: str | list) -> Optional[list]:
+def build_features_list(feature_names: str) -> Optional[list]:
     """Gets a list of Vision features for given list of names.
 
     Args:
@@ -121,11 +121,7 @@ def build_features_list(feature_names: str | list) -> Optional[list]:
     """
 
     features_list = []
-
-    features_items = feature_names
-    if isinstance(feature_names, str):
-        features_items = feature_names.split(",")
-
+    features_items = feature_names.split(",")
     for feature_name in features_items:
         feature = get_feature_by_name(feature_name.upper().strip('"').strip())
         if feature:
@@ -535,7 +531,9 @@ def handle_annotation(request):
         logging.info("Env. features: %s", features_env)
         features_list = build_features_list(features_env)
     # override annotation features with the ones from the request if provided
-    if features_http and isinstance(features_http, str | list):
+    if features_http and isinstance(features_http, list):
+        features_http = ','.join(features_http)
+    if features_http and isinstance(features_http, str):
         logging.info("Request features: %s", features_http)
         features_list = build_features_list(features_http)
     logging.info("Annotating for features: %s", features_list)


### PR DESCRIPTION
The http endpoint is currently throwing a `500` if the user enters an invalid features parameter like `["LABEL_DETECTION"]` instead of `"LABEL_DETECTION"`

```
curl -X POST \
    -H "Authorization: Bearer $(gcloud auth print-access-token)" \
    -H "Content-Type: application/json" \
    -d '{
      "image_uri": "gs://cloud-samples-data/vision/eiffel_tower.jpg",
      "features": ["LABEL_DETECTION"]
    }' \
    "https://us-central1-nathen-sandbox.cloudfunctions.net/annotate-http/annotate"
```

I could see an argument for doing more robust handling or returning a descriptive `400`, but this seemed like a good way to allow a more flexible endpoint. (We've been getting a lot of `500` errors in Duet AI workshop testing when Duet is generating the curl commands.)